### PR TITLE
Divide templatetag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 /example/database.sqlite3
 /example/GeoLiteCity.dat
 /django_user_sessions.egg-info/

--- a/user_sessions/templatetags/user_sessions.py
+++ b/user_sessions/templatetags/user_sessions.py
@@ -15,7 +15,7 @@ BROWSERS = (
     (re.compile('Opera'), _('Opera')),
     (re.compile('IE'), _('Internet Explorer')),
 )
-DEVICES = (
+PLATFORMS = (
     (re.compile('Windows Mobile'), _('Windows Mobile')),
     (re.compile('Android'), _('Android')),
     (re.compile('Linux'), _('Linux')),
@@ -54,7 +54,7 @@ def platform(value):
     """
 
     platform = None
-    for regex, name in DEVICES:
+    for regex, name in PLATFORMS:
         if regex.search(value):
             platform = name
             break
@@ -66,7 +66,9 @@ def platform(value):
 def browser(value):
     """
     Transform a User Agent into human readable text.
+    
     Example output:
+    
     * Safari
     * Chrome
     * Safari
@@ -99,7 +101,6 @@ def device(value):
     """
 
     browser_ = browser(value)
-
     platform_ = platform(value)
 
     if browser_ and platform_:

--- a/user_sessions/templatetags/user_sessions.py
+++ b/user_sessions/templatetags/user_sessions.py
@@ -40,6 +40,50 @@ DEVICES = (
 
 
 @register.filter
+def platform(value):
+    """
+    Transform a User Agent into human readable text.
+
+    Example output:
+
+    * iPhone
+    * Windows 8.1
+    * macOS
+    * Linux
+    * None
+    """
+
+    platform = None
+    for regex, name in DEVICES:
+        if regex.search(value):
+            platform = name
+            break
+
+    return platform
+
+
+@register.filter
+def browser(value):
+    """
+    Transform a User Agent into human readable text.
+    Example output:
+    * Safari
+    * Chrome
+    * Safari
+    * Firefox
+    * None
+    """
+
+    browser = None
+    for regex, name in BROWSERS:
+        if regex.search(value):
+            browser = name
+            break
+
+    return browser
+
+
+@register.filter
 def device(value):
     """
     Transform a User Agent into human readable text.
@@ -54,29 +98,21 @@ def device(value):
     * None
     """
 
-    browser = None
-    for regex, name in BROWSERS:
-        if regex.search(value):
-            browser = name
-            break
+    browser_ = browser(value)
 
-    device = None
-    for regex, name in DEVICES:
-        if regex.search(value):
-            device = name
-            break
+    platform_ = platform(value)
 
-    if browser and device:
+    if browser_ and platform_:
         return _('%(browser)s on %(device)s') % {
-            'browser': browser,
-            'device': device
+            'browser': browser_,
+            'device': platform_
         }
 
-    if browser:
-        return browser
+    if browser_:
+        return browser_
 
-    if device:
-        return device
+    if platform_:
+        return platform_
 
     return None
 


### PR DESCRIPTION
## Description
In user_sessions/templatetags/user_sessions.py I added two template filters, platform and browser, which are splitted device template filter.

## Motivation and Context
We have faced with the necessity to use name of browser and name of platform in different lines of code. So, as a result of the splitting, there's no longer a need to override the template filter for these purposes. I think that two added above-mentioned filters are a frequent need, especially while HTML coding.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
